### PR TITLE
Fix address calculation in backend/aarray.d AArray.apply

### DIFF
--- a/src/dmd/backend/aarray.d
+++ b/src/dmd/backend/aarray.d
@@ -334,7 +334,7 @@ nothrow:
         {
             while (e)
             {
-                auto result = dg(cast(Key*)(e + 1), cast(Value*)(e + 1) + aligned_keysize);
+                auto result = dg(cast(Key*)(e + 1), cast(Value*)(cast(void*)(e + 1) + aligned_keysize));
                 if (result)
                     return result;
                 e = e.next;
@@ -649,6 +649,14 @@ void testAArray()
     auto values = aa.values();
     assert(values.length == 1);
     assert(values[0] == false);
+
+    AArray!(Tinfo!int, bool) aa2;
+    int key = 10;
+    bool* getpv = aa2.get(&key);
+    aa2.apply(delegate(int* pk, bool* pv) @trusted {
+        assert(pv is getpv);
+        return 0;
+    });
 }
 
 void testAApair()


### PR DESCRIPTION
AArray is unused as far as I know, I stumbled upon this bug hacking around the back end.

It's  a trivial fix that makes the address calculation in ```AArray.apply``` identical to the other getter functions.